### PR TITLE
Indt/handle line continuation

### DIFF
--- a/stub_format.py
+++ b/stub_format.py
@@ -382,7 +382,7 @@ def generate_stub_functions(file_data, filename):
     lines = file_data.split("\n")
     scope = []
     qualifier = ()
-    output = "#include " + filename + "\n\n"
+    output = '#include "' + filename + '"\n\n'
     indent = 0
     for l in lines:
         tokens = l.split(" ")

--- a/stub_format.py
+++ b/stub_format.py
@@ -355,6 +355,7 @@ def remove_directives(file_data):
     lines = file_data.split("\n")
     level = 0
     conditioned = ""
+    line_continued = False
     for line in lines:
         if level > 0:
             eipos = line.find("#endif")
@@ -368,8 +369,16 @@ def remove_directives(file_data):
             level += 1
 
         if level == 0:
-            if not line.strip().startswith('#'):
+            line_stripped = line.strip()
+            line_starts_with_hash = line_stripped.startswith('#')
+            line_ends_with_backslsh = line_stripped.endswith('\\')
+            if line_continued:
+                line_continued = line_ends_with_backslsh
+            elif line_starts_with_hash:
+                line_continued = line_ends_with_backslsh
+            else:
                 conditioned += line + "\n"
+                line_continued = False
 
     return conditioned
 

--- a/stub_format.py
+++ b/stub_format.py
@@ -352,6 +352,7 @@ def generate_stub_functions(file_data, filename):
     file_data = remove_comments(file_data)
     lines = file_data.split("\n")
     scope = []
+    qualifier = ()
     output = "#include " + filename + "\n\n"
     indent = 0
     for l in lines:

--- a/test.h
+++ b/test.h
@@ -1,11 +1,22 @@
 #ifndef HEADER_H
 #define HEADER_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+void global_c_func_void_void(void);
+int global_c_func_int_int(int val);
+
+#ifdef __cplusplus
+}
+#endif
+
 namespace stub_test
 {
     const void* function_a(); // function with no args
     void function_b(int param_a, int* pointer, const int& ref); // function with args
-    
+
     class my_class
     {
     public:
@@ -17,21 +28,21 @@ namespace stub_test
         const void* function_d() = 0;       // test for virtual function
         int test = int(1);                  // initialiser
     private:
-    
+
         int function_const() const;             // const member function
         void (*function_pointer)(int b, int c); // test for function pointer
-        
+
         inline void inline_func()
         {
             int a = (int)0.0f; // some code to avoid
         }
     };
-    
+
     namespace deeper
     {
         void function_e(int a, float b, test c);
         int function_f(int b = 0); // test for default args
-        
+
         class scope_class // ignore this
         {
             // parenthesis might span multiple lines
@@ -43,21 +54,21 @@ namespace stub_test
             );
         };
     }
-    
+
     /*
         int commented_out_function_a(int b = 0);
-        
+
         struct commented_out
         {
             int a;
             int b;
             int c;
         };
-        
+
     */ void function_h(int b); // testing code on the same line as end comment
-    
+
     // int commented_out_function_b();
-    
+
     void 😎 (int a, int 🕺); // test for utf8
 }
 

--- a/test.h
+++ b/test.h
@@ -1,8 +1,11 @@
 #ifndef HEADER_H
 #define HEADER_H
 
+void global_func_void_void(void);
+int global_func_int_int(int val);
+
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 void global_c_func_void_void(void);
@@ -71,5 +74,19 @@ namespace stub_test
 
     void 😎 (int a, int 🕺); // test for utf8
 }
+
+void global_func_void_void_2(void);
+int global_func_int_int_2(int val);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void global_c_func_void_void_2(void);
+int global_c_func_int_int_2(int val);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/test.h
+++ b/test.h
@@ -15,6 +15,13 @@ int global_c_func_int_int(int val);
 }
 #endif
 
+#define TEST_SINGLE_LINE "single line (with parenthesis) !!"
+
+#define TEST_MULTI_LINE "multi-line 1 (with parenthesis) !!" \
+    "multi-line 2 (with parenthesis) !!" \
+    "multi-line 3 (with parenthesis) !!" \
+    "multi-line end (with parenthesis) !!"
+
 namespace stub_test
 {
     const void* function_a(); // function with no args


### PR DESCRIPTION
Comment out preprocessor directives (macros) that span multiple line with backslash line continuation character.
This addresses issues where macros contain parenthesis that can be detected as part of a function signature.